### PR TITLE
Users/ayer/dbtests

### DIFF
--- a/backend/__tests__/db/prompt.test.ts
+++ b/backend/__tests__/db/prompt.test.ts
@@ -1,0 +1,181 @@
+import {PrismaClient} from '@prisma/client';
+import {afterAll, beforeAll, describe, expect, it} from '@jest/globals';
+
+const prisma = new PrismaClient();
+let testUserId: string;
+
+describe('Prisma Prompt Model', () => {
+    beforeAll(async () => {
+        const user = await prisma.user.create({
+            data: {
+                email: `testemail.${Date.now()}@qmail.com`,
+                displayName: 'Prompt User',
+            },
+        });
+        testUserId = user.id;
+    });
+
+    afterAll(async () => {
+        await prisma.prompt.deleteMany({where: {userId: testUserId}});
+        await prisma.user.delete({where: {id: testUserId}});
+        await prisma.$disconnect();
+    });
+
+    it('should create and fetch a prompt for the user', async () => {
+        const createdPrompt = await prisma.prompt.create({
+            data: {
+                userId: testUserId,
+                title: 'Sample Prompt',
+                persona: 'Engineer',
+                context: 'Building tests',
+                task: 'Write unit tests for prompt model',
+                output: 'A passing test',
+                constraints: 'Must include all fields',
+            },
+        });
+
+        const foundPrompt = await prisma.prompt.findUnique({
+            where: {id: createdPrompt.id},
+        });
+
+        expect(foundPrompt).not.toBeNull();
+        expect(foundPrompt?.title).toBe('Sample Prompt');
+        expect(foundPrompt?.userId).toBe(testUserId);
+    });
+
+    it('should apply default values for score and isBookmarked', async () => {
+
+        const createdPrompt = await prisma.prompt.create({
+            data: {
+                userId: testUserId,
+                title: 'Sample Prompt',
+                persona: 'Engineer',
+                context: 'Building tests',
+                task: 'Write unit tests for prompt model',
+                output: 'A passing test',
+                constraints: 'Must include all fields',
+            },
+        });
+
+        const userId = testUserId;
+
+        const prompt = await prisma.prompt.create({
+            data: {
+                userId,
+                title: 'Defaults Test',
+                persona: 'Defaults',
+                context: 'Checking defaults',
+                task: 'Leave out score and isBookmarked',
+                output: 'Check default values',
+                constraints: 'None',
+            },
+        });
+
+        expect(prompt.score).toBe(0);
+        expect(prompt.isBookmarked).toBe(false);
+    });
+
+    it('should update the title and score of a prompt', async () => {
+        const createdPrompt = await prisma.prompt.create({
+            data: {
+                userId: testUserId,
+                title: 'Sample Prompt',
+                persona: 'Engineer',
+                context: 'Building tests',
+                task: 'Write unit tests for prompt model',
+                output: 'A passing test',
+                constraints: 'Must include all fields',
+            },
+        });
+
+        const promptId = createdPrompt.id;
+
+
+        const updatedPrompt = await prisma.prompt.update({
+            where: {id: promptId},
+            data: {
+                title: 'Updated Title',
+                score: 10,
+            },
+        });
+
+        expect(updatedPrompt.title).toBe('Updated Title');
+        expect(updatedPrompt.score).toBe(10);
+    });
+
+
+    it('should delete a prompt and confirm it no longer exists', async () => {
+
+        const prompt = await prisma.prompt.create({
+            data: {
+                userId: testUserId,
+                title: 'To Be Deleted',
+                persona: 'Cleaner',
+                context: 'Delete testing',
+                task: 'Test delete',
+                output: 'Should be removed',
+                constraints: 'None',
+            },
+        });
+
+
+        await prisma.prompt.delete({
+            where: {id: prompt.id},
+        });
+
+
+        const found = await prisma.prompt.findUnique({
+            where: {id: prompt.id},
+        });
+
+        expect(found).toBeNull();
+    });
+
+    it('should delete prompts when the user is deleted (cascade)', async () => {
+
+        const user = await prisma.user.create({
+            data: {
+                email: `testemail.${Date.now()}@qmail.com`,
+                displayName: 'Cascade User',
+            },
+        });
+
+
+        await prisma.prompt.createMany({
+            data: [
+                {
+                    userId: user.id,
+                    title: 'Cascade Prompt 1',
+                    persona: 'Cascade',
+                    context: 'User delete',
+                    task: 'Delete test 1',
+                    output: 'Output 1',
+                    constraints: 'None',
+                },
+                {
+                    userId: user.id,
+                    title: 'Cascade Prompt 2',
+                    persona: 'Cascade',
+                    context: 'User delete',
+                    task: 'Delete test 2',
+                    output: 'Output 2',
+                    constraints: 'None',
+                },
+            ],
+        });
+
+
+        await prisma.user.delete({
+            where: { id: user.id },
+        });
+
+
+        const remainingPrompts = await prisma.prompt.findMany({
+            where: { userId: user.id },
+        });
+
+        expect(remainingPrompts.length).toBe(0);
+    });
+
+
+});

--- a/backend/__tests__/db/user.test.ts
+++ b/backend/__tests__/db/user.test.ts
@@ -1,0 +1,172 @@
+import {PrismaClient} from '@prisma/client';
+import {afterAll, describe, expect, it} from "@jest/globals";
+
+const prisma = new PrismaClient();
+
+describe('Prisma DB Connection', () => {
+    afterAll(async () => {
+        await prisma.$disconnect();
+    });
+
+    it('should return an array of users (can be empty)', async () => {
+        const users = await prisma.user.findMany();
+        expect(Array.isArray(users)).toBe(true);
+    });
+
+    it('should create, retrieve, and delete a test user', async () => {
+        const testEmail = `testemail.${Date.now()}@qmail.com`;
+
+        await prisma.user.deleteMany({
+            where: {email: testEmail},
+        });
+
+        const createdUser = await prisma.user.create({
+            data: {
+                email: testEmail,
+                displayName: 'Test User',
+            },
+        });
+
+        const userId = createdUser.id;
+
+        const foundUser = await prisma.user.findUnique({
+            where: {id: createdUser.id},
+        });
+
+        expect(foundUser).not.toBeNull();
+        expect(foundUser?.email).toBe(testEmail);
+        expect(foundUser?.displayName).toBe('Test User');
+
+
+        await prisma.user.delete({
+            where: {id: createdUser.id},
+        });
+    });
+
+    it('should find a user by ID', async () => {
+        const email = `testemail.${Date.now()}@qmail.com`;
+
+        const createdUser = await prisma.user.create({
+            data: {
+                email,
+                displayName: 'FindById User',
+            },
+        });
+
+        const foundUser = await prisma.user.findUnique({
+            where: {id: createdUser.id},
+        });
+
+        expect(foundUser).not.toBeNull();
+        expect(foundUser?.email).toBe(email);
+
+
+        await prisma.user.delete({where: {id: createdUser.id}});
+    });
+
+    it('should find a user by email', async () => {
+        const email = `testemail.${Date.now()}@qmail.com`;
+
+        const createdUser = await prisma.user.create({
+            data: {
+                email,
+                displayName: 'FindByEmail User',
+            },
+        });
+
+        const foundUser = await prisma.user.findUnique({
+            where: {email},
+        });
+
+        expect(foundUser).not.toBeNull();
+        expect(foundUser?.id).toBe(createdUser.id);
+        expect(foundUser?.displayName).toBe('FindByEmail User');
+
+        await prisma.user.delete({where: {id: createdUser.id}});
+    });
+
+    it('should fail to create a user with a duplicate email', async () => {
+        const email = `testemail.${Date.now()}@qmail.com`;
+
+
+        const user1 = await prisma.user.create({
+            data: {
+                email,
+                displayName: 'Original User',
+            },
+        });
+
+
+        let errorOccurred = false;
+
+        try {
+            await prisma.user.create({
+                data: {
+                    email,
+                    displayName: 'Duplicate User',
+                },
+            });
+        } catch (error: any) {
+            errorOccurred = true;
+            expect(error.code).toBe('P2002');
+        }
+
+        expect(errorOccurred).toBe(true);
+
+
+        await prisma.user.delete({where: {id: user1.id}});
+    });
+
+    it('should find a user with related prompts', async () => {
+        const email = `testemail.${Date.now()}@qmail.com`;
+
+
+        const user = await prisma.user.create({
+            data: {
+                email,
+                displayName: 'User With Prompts',
+            },
+        });
+
+
+        await prisma.prompt.createMany({
+            data: [
+                {
+                    userId: user.id,
+                    title: 'Prompt 1',
+                    persona: 'Dev',
+                    context: 'Testing',
+                    task: 'Write code',
+                    output: 'Output 1',
+                    constraints: 'None',
+                },
+                {
+                    userId: user.id,
+                    title: 'Prompt 2',
+                    persona: 'Tester',
+                    context: 'Validation',
+                    task: 'Write test',
+                    output: 'Output 2',
+                    constraints: 'Time limit',
+                },
+            ],
+        });
+
+
+        const userWithPrompts = await prisma.user.findUnique({
+            where: {id: user.id},
+            include: {prompts: true},
+        });
+
+        expect(userWithPrompts).not.toBeNull();
+        expect(userWithPrompts?.prompts.length).toBe(2);
+        expect(userWithPrompts?.prompts[0].title).toBe('Prompt 1');
+        expect(userWithPrompts?.prompts[1].title).toBe('Prompt 2');
+
+
+        await prisma.prompt.deleteMany({where: {userId: user.id}});
+        await prisma.user.delete({where: {id: user.id}});
+    });
+
+
+});


### PR DESCRIPTION
## Prisma Model Tests (Jest + PrismaClient)

This PR includes comprehensive tests for verifying database operations using **Prisma Client** and **Jest**, before building the API layer. These tests ensure that the database models (`User` and `Prompt`) behave as expected and follow the rules defined in the Prisma schema (e.g., constraints, defaults, relationships).

### Test Location

All tests are located under the `__tests__/db/` directory:
tests/db/ ├── user.test.ts └── prompt.test.ts
---

### Test Cases Overview

#### `user.test.ts`

| Test Name | Description |
|-----------|-------------|
| `should return an array of users` | Confirms the Prisma client is connected and `findMany()` returns an array |
| `should create, retrieve, and delete a test user` | Verifies that a user can be created, fetched by ID, and deleted |
| `should find a user by ID` | Checks if the user can be retrieved by `id` |
| `should find a user by email` | Checks if the user can be retrieved by `email` (which is unique) |
| `should fail to create a user with a duplicate email` | Ensures Prisma throws `P2002` for duplicate emails |
| `should find a user with related prompts` | Verifies the 1-to-many relationship between `User` and `Prompt` |

---

#### `prompt.test.ts`

| Test Name | Description |
|-----------|-------------|
| `should create and fetch a prompt for the user` | Ensures a prompt can be created and retrieved by `id` |
| `should apply default values for score and isBookmarked` | Confirms that default values (`score = 0`, `isBookmarked = false`) are applied |
| `should update the title and score of a prompt` | Verifies the update functionality works correctly |
| `should delete a prompt and confirm it no longer exists` | Ensures prompt deletion is effective and permanent |
| `should delete prompts when the user is deleted (cascade)` | Tests the `onDelete: Cascade` rule between user and prompts |

---

###  Running the Tests

Make sure the Prisma client is generated and your `.env` is correctly set up.

```bash
# Generate Prisma client (if needed)
npx prisma generate

# Run all tests
yarn test
