### PR TITLE
Users/nkolesnikova/update tests - Update backend tests

### DIFF
--- a/backend/__tests__/routes/authRoutes.test.ts
+++ b/backend/__tests__/routes/authRoutes.test.ts
@@ -2,12 +2,12 @@ import express, { Request, Response } from "express";
 import request from "supertest";
 import { describe, expect, beforeEach, jest } from "@jest/globals";
 
-import { authRoute } from "../../src/routes/authRoutes.ts";
+import { authRoute } from "../../src/routes/authRoutes";
 import {
   authServices,
   callbacks,
   invalidRoutes,
-} from "../../__mocks__/mockRoutes.ts";
+} from "../../__mocks__/mockRoutes.js";
 
 jest.mock("../../src/controllers/index", () => ({
   authController: {

--- a/backend/__tests__/services/throwGoogleError.test.ts
+++ b/backend/__tests__/services/throwGoogleError.test.ts
@@ -1,5 +1,5 @@
-import { GoogleAPIError, throwGoogleError } from "../../src/services/index.ts";
-import { errorMessages } from "../../__mocks__/mockErrorMessges.ts";
+import { GoogleAPIError, throwGoogleError } from "../../src/services/index";
+import { errorMessages } from "../../__mocks__/mockErrorMessges";
 
 describe("throwGitHubError", () => {
   test("throws GitHubAPIError with provided message", () => {

--- a/backend/__tests__/utils/generateToken.test.ts
+++ b/backend/__tests__/utils/generateToken.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, jest } from "@jest/globals";
 
-import { generateToken } from "../../src/utils/index.ts";
-import { mockUsers } from "../../__mocks__/mockUsers.ts";
+import { generateToken } from "../../src/utils/index";
+import { mockUsers } from "../../__mocks__/mockUsers";
 
 jest.mock("jsonwebtoken", () => ({
   sign: jest.fn().mockImplementation(() => "foo_bar"),

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -9,4 +9,7 @@ export default {
   transformIgnorePatterns: [
     "node_modules/(?!(octokit|@octokit|before-after-hook|universal-user-agent)/)",
   ],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };


### PR DESCRIPTION
These changes propose a resolution to Jest conflicts with '.js' extensions. Before adding the module mapper Jest was not able to find '.ts' files.

Inside jest.config.js:
```javascript
  moduleNameMapper: {
    "^(\\.{1,2}/.*)\\.js$": "$1",
  },
```

Updates: 
- Remove all extensions from imports inside test files;
- Add a module mapper to remove '.js' extensions from imports - this allows Jest to correctly resolve TypeScript files.

---

Module mapper will:
- Remove '.js' extensions from imports;
- Jest can then correctly find the '.ts' files.

