### PR TITLE
update(backend/config): Update Google and GitHub Auth redirect url to a deployed link

### DIFF
--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -12,7 +12,8 @@ export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 export const GOOGLE_ACCESS_TOKEN_URL = process.env.GOOGLE_ACCESS_TOKEN_URL;
 
-export const GOOGLE_CALLBACK_URL = "http://localhost:8000/google-callback";
+export const GOOGLE_CALLBACK_URL =
+  "https://v54-tier3-team-37.onrender.com/google-callback";
 export const GOOGLE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",

--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -2,15 +2,14 @@
 export const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
 export const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 
-export const GITHUB_TOKEN_INFO_URL = process.env.GITHUB_TOKEN_INFO_URL;
 export const GITHUB_REDIRECT_URL = `https://github.com/login/oauth/authorize?`;
+export const GITHUB_CALLBACK_URL =
+  "https://v54-tier3-team-37.onrender.com/github-callback";
 
 // Google OAuth variables
-export const GOOGLE_OAUTH_URL = process.env.GOOGLE_OAUTH_URL;
 export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 
 export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
-export const GOOGLE_ACCESS_TOKEN_URL = process.env.GOOGLE_ACCESS_TOKEN_URL;
 
 export const GOOGLE_CALLBACK_URL =
   "https://v54-tier3-team-37.onrender.com/google-callback";

--- a/backend/src/services/GitHubAuth.ts
+++ b/backend/src/services/GitHubAuth.ts
@@ -8,6 +8,7 @@ import {
   GITHUB_CLIENT_SECRET,
   GITHUB_CLIENT_ID,
   GITHUB_REDIRECT_URL,
+  GITHUB_CALLBACK_URL,
 } from "../config/authConfig.js";
 
 import { extractCode } from "../utils/index.js";
@@ -35,7 +36,8 @@ class GitHubAuth {
   constructor(
     private readonly clientId: string,
     private readonly clientSecret: string,
-    private readonly redirectUrl: string
+    private readonly redirectUrl: string,
+    private readonly callbackUrl: string
   ) {
     // Initialize the OAuth2 client for Google authentication
     // This handles sign-in, token exchange, and token refreshing
@@ -46,7 +48,7 @@ class GitHubAuth {
   }
 
   generateAuthUrl = (state: string) => {
-    return `${this.redirectUrl}client_id=${this.clientId}&scope=${this.scope}&state=${state}`;
+    return `${this.redirectUrl}client_id=${this.clientId}&redirect_uri=${this.callbackUrl}&scope=${this.scope}&state=${state}`;
   };
 
   authenticate = async (req: any) => {
@@ -102,5 +104,6 @@ class GitHubAuth {
 export const githubAuth = new GitHubAuth(
   String(GITHUB_CLIENT_ID),
   String(GITHUB_CLIENT_SECRET),
-  GITHUB_REDIRECT_URL
+  GITHUB_REDIRECT_URL,
+  GITHUB_CALLBACK_URL
 );


### PR DESCRIPTION
### Google

Replaced 
```javascript
export const GOOGLE_CALLBACK_URL = "http://localhost:8000/google-callback";
```
with
```javascript
export const GOOGLE_CALLBACK_URL = "https://v54-tier3-team-37.onrender.com/google-callback";
```

---

### GitHub

So for GitHub all of the redirect links have actually been already updated inside the Developer setting of GitHub. I googled a bit and found that potentially including a callback URL will solve the redirect issue. It turns out that it might be optional in development, but not in production.
The callback URL it is added now:

```javascript
export const GITHUB_CALLBACK_URL =
  "https://v54-tier3-team-37.onrender.com/github-callback";
```

```javascript
  generateAuthUrl = (state: string) => {
    return `${this.redirectUrl}client_id=${this.clientId}&redirect_uri=${this.callbackUrl}&scope=${this.scope}&state=${state}`;
  };
```