### PR TITLE
Users/nkolesnikova/serve static files

### DIFF
--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -1,9 +1,14 @@
 import express from "express";
+import path from "path";
 import session from "express-session";
 import { userRoute, authRoute } from "../routes/index.js";
 
 export const configApp = () => {
   const app = express();
+
+  // Serve static files
+  const __dirname = import.meta.dirname;
+  app.use(express.static(path.join(__dirname, "..", "static")));
 
   const sessionSecret = String(process.env.SESSION_SECRET);
   app.use(

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -7,7 +7,7 @@ export const configApp = () => {
   const app = express();
 
   // Serve static files
-  const __dirname = import.meta.dirname;
+  const __dirname = path.resolve();
   app.use(express.static(path.join(__dirname, "..", "static")));
 
   const sessionSecret = String(process.env.SESSION_SECRET);

--- a/backend/src/static/index.html
+++ b/backend/src/static/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hello, Team 37!</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>


### PR DESCRIPTION
Added logic that will serve static files from `static` folder.  

The ultimate logic is as follows:
Once React assets are built, a GitHub workflow would pick that up and copy into static folder.

I know that there are many ways to do this, so I am opened to feedback and discussion!

Changes:
```javascript
  // Serve static files
  const __dirname = path.resolve();
  app.use(express.static(path.join(__dirname, "..", "static")));
```

I had to change the way the `dirname` is obtained, because `import` was bothering Jest.