### PR TITLE
Users/ayer/user crud

### DIFF
--- a/backend/prisma/migrations/20250326001608_add_user_image/migration.sql
+++ b/backend/prisma/migrations/20250326001608_add_user_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "image" VARCHAR(255);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   id          String   @id @default(uuid()) @db.Uuid
   email       String   @unique @db.VarChar(255)
   displayName String   @db.VarChar(32)
+  image       String?  @db.VarChar(255)
   createdAt   DateTime @default(now()) @db.Timestamp(0)
 
   prompts     Prompt[]

--- a/backend/src/controllers/index.ts
+++ b/backend/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export * as authController from "./authController.js";
+export * as userController from "./userController.js";

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,0 +1,34 @@
+import {Request, Response} from 'express';
+import {PrismaClient, User} from '@prisma/client';
+import {mapUserToPublic} from "../types/mappers/userMapper.js";
+
+const prisma = new PrismaClient();
+
+/**
+ * GET /users/:userId
+ * Retrieves a user profile by user ID.
+ * Returns 404 if the user is not found.
+ */
+export const getUserProfile = async (
+    req: Request,
+    res: Response
+): Promise<void> => {
+    try {
+        const {userId} = req.params;
+
+        const user = await prisma.user.findUnique({
+            where: {id: userId},
+        });
+
+        if (!user) {
+            res.status(404).json({error: "User not found"});
+            return;
+        }
+
+        const publicUser = mapUserToPublic(user as User);
+        res.status(200).json(publicUser);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({error: "Something went wrong"});
+    }
+};

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,10 +1,11 @@
-import {Router, RequestHandler} from "express";
+import {RequestHandler, Router} from "express";
 
 import {userController} from "../controllers/index.js";
 
 
 export const userRoute: Router = Router({});
 
+// GET /users/:userId → Fetch user profile by ID
 userRoute.get("/:userId", userController.getUserProfile as RequestHandler);
 
 

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,46 +1,11 @@
-import {Router, Request, Response} from "express";
-import prisma from "../prisma.js";
+import {Router, RequestHandler} from "express";
+
+import {userController} from "../controllers/index.js";
+
 
 export const userRoute: Router = Router({});
 
-userRoute.post("/", async (req, res) => {
-    try {
-        const { email, displayName } = req.body;
-        const newUser = await prisma.user.create({
-            data: { email, displayName },
-        });
-        res.status(201).json(newUser);
-    } catch (error) {
-        console.error(error);
-        res.status(500).json({ error: "Something went wrong" });
-    }
-});
-
-userRoute.get("/:userId", async (req: Request, res: Response) => {
-    try {
-        const { userId } = req.params;
-
-        const user = await prisma.user.findUnique({
-            where: { id: userId },
-            include: { prompts: true },
-        });
-
-        if (!user) {
-            res.status(404).json({ error: "User not found" });
-            return
-        }
-
-        res.status(200).json(user);
-        return
-
-    } catch (error) {
-        console.error(error);
-        res.status(500).json({ error: "Something went wrong" });
-    }
-});
-
-
-
+userRoute.get("/:userId", userController.getUserProfile as RequestHandler);
 
 
 

--- a/backend/src/types/mappers/userMapper.ts
+++ b/backend/src/types/mappers/userMapper.ts
@@ -1,0 +1,28 @@
+import {User} from "@prisma/client";
+
+/**
+ * Represents the shape of user data returned to the client.
+ *
+ */
+export type PublicUser = {
+    id: string;
+    email: string;
+    displayName: string;
+    image: string | null;
+    createdAt: string;
+};
+
+/**
+ * Maps a full User object to a PublicUser DTO.
+ * @param user - The Prisma User object
+ * @returns A PublicUser object suitable for API responses
+ */
+export const mapUserToPublic = (user: User): PublicUser => {
+    return {
+        id: user.id,
+        email: user.email,
+        displayName: user.displayName,
+        image: user.image,
+        createdAt: user.createdAt.toISOString(),
+    };
+};


### PR DESCRIPTION
## Add getUserProfile Endpoint with Public User Mapping

### What's Included:

Implemented getUserProfile controller to retrieve user by ID

Returned user data using a mapUserToPublic() function to expose only public-facing fields

Added error handling for missing users (404) and unexpected failures (500)

Registered the route: GET /users/:userId

Affected Files:
userController.ts
userRoutes.ts
userMapper.ts


{
    "id": "3455db75-7480-4803-88a0-d4564b8f63a6",
    "email": "johndoe777@example.com",
    "displayName": "John Doe",
    "image": null,
    "createdAt": "2025-03-22T13:53:17.000Z"
}