### PR TITLE
Users/nkolesnikova/more link updates - Update callback urls for both services

### DIFF
--- a/backend/__tests__/config/googleCallbackUrl.test.ts
+++ b/backend/__tests__/config/googleCallbackUrl.test.ts
@@ -1,0 +1,37 @@
+import {
+  GOOGLE_CALLBACK_URL_DEV,
+  GOOGLE_CALLBACK_URL_PROD,
+} from "../../src/config/authConfig";
+
+describe("Google callback URL", () => {
+  const appEnv = process.env;
+
+  beforeEach(() => {
+    // Reset modules cache before each test
+    jest.resetModules();
+    process.env = { ...appEnv };
+  });
+
+  afterAll(() => {
+    // Set app environment to the original value
+    process.env = appEnv;
+  });
+
+  test("uses development Google callback URL in development environment", async () => {
+    process.env.NODE_ENV = "development";
+    const { GOOGLE_CALLBACK_URL } = await import("../../src/config/authConfig");
+    expect(GOOGLE_CALLBACK_URL).toEqual(GOOGLE_CALLBACK_URL_DEV);
+  });
+
+  test("uses development Google callback URL in undefined environment", async () => {
+    process.env.NODE_ENV = "";
+    const { GOOGLE_CALLBACK_URL } = await import("../../src/config/authConfig");
+    expect(GOOGLE_CALLBACK_URL).toEqual(GOOGLE_CALLBACK_URL_DEV);
+  });
+
+  test("uses production Google callback URL in production environment", async () => {
+    process.env.NODE_ENV = "production";
+    const { GOOGLE_CALLBACK_URL } = await import("../../src/config/authConfig");
+    expect(GOOGLE_CALLBACK_URL).toEqual(GOOGLE_CALLBACK_URL_PROD);
+  });
+});

--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -4,7 +4,7 @@ export const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 
 export const GITHUB_REDIRECT_URL = `https://github.com/login/oauth/authorize?`;
 export const GITHUB_CALLBACK_URL =
-  "https://v54-tier3-team-37.onrender.com/github-callback";
+  "https://v54-tier3-team-37.onrender.com/auth/github-callback";
 
 // Google OAuth variables
 export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;

--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -11,8 +11,11 @@ export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 
 export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
 
-export const GOOGLE_CALLBACK_URL =
-  "https://v54-tier3-team-37.onrender.com/google-callback";
+const production = process.env.NODE_ENV === "production";
+export const GOOGLE_CALLBACK_URL = production
+  ? "https://v54-tier3-team-37.onrender.com/google-callback"
+  : "http://localhost:8000/google-callback";
+
 export const GOOGLE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",

--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -8,13 +8,15 @@ export const GITHUB_CALLBACK_URL =
 
 // Google OAuth variables
 export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
-
 export const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+export const GOOGLE_CALLBACK_URL_DEV = "http://localhost:8000/google-callback";
+export const GOOGLE_CALLBACK_URL_PROD =
+  "https://v54-tier3-team-37.onrender.com/google-callback";
 
 const production = process.env.NODE_ENV === "production";
 export const GOOGLE_CALLBACK_URL = production
-  ? "https://v54-tier3-team-37.onrender.com/google-callback"
-  : "http://localhost:8000/google-callback";
+  ? GOOGLE_CALLBACK_URL_PROD
+  : GOOGLE_CALLBACK_URL_DEV;
 
 export const GOOGLE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
After consulting with GitHub docs on how to correctly construct a callback URL,  I have found that it **_must_** have a path, so 'auth' path is added:

```javascript
export const GITHUB_CALLBACK_URL =
  "https://v54-tier3-team-37.onrender.com/auth/github-callback";
```

---

Added a ternary for checking running environment and setting a relevant URL:
```javascript
const production = process.env.NODE_ENV === "production";
export const GOOGLE_CALLBACK_URL = production
  ? GOOGLE_CALLBACK_URL_PROD
  : GOOGLE_CALLBACK_URL_DEV;
```

Added tests to ensure that the callback URL is correctly assigned for production and dev environments.