### PR TITLE
feat(db-schema): add PromptOutput model and imageUrl to User

### DIFF
--- a/backend/prisma/migrations/20250327163313_init_prompt_output_and_user_image/migration.sql
+++ b/backend/prisma/migrations/20250327163313_init_prompt_output_and_user_image/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "imageUrl" VARCHAR(255);
+
+-- CreateTable
+CREATE TABLE "prompt_outputs" (
+    "id" UUID NOT NULL,
+    "promptId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "prompt_outputs_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "prompt_outputs" ADD CONSTRAINT "prompt_outputs_promptId_fkey" FOREIGN KEY ("promptId") REFERENCES "prompts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "prompt_outputs" ADD CONSTRAINT "prompt_outputs_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,13 +8,32 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+
+model PromptOutput {
+  id          String   @id @default(uuid()) @db.Uuid
+  promptId    String   @db.Uuid
+  userId      String   @db.Uuid
+  content     String   @db.Text
+  metadata    Json?    @db.JsonB
+  version     Int      @default(1)
+  createdAt   DateTime @default(now()) @db.Timestamp(0)
+
+
+  prompt      Prompt   @relation(fields: [promptId], references: [id], onDelete: Cascade)
+  user        User     @relation(fields: [userId], references: [id])
+
+  @@map("prompt_outputs")
+}
+
 model User {
   id          String   @id @default(uuid()) @db.Uuid
   email       String   @unique @db.VarChar(255)
   displayName String   @db.VarChar(32)
+  imageUrl    String? @db.VarChar(255)
   createdAt   DateTime @default(now()) @db.Timestamp(0)
 
   prompts     Prompt[]
+  outputs     PromptOutput[]
 
   @@map("users")
 }
@@ -33,7 +52,9 @@ model Prompt {
   createdAt    DateTime @default(now()) @db.Timestamp(0)
 
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  outputs      PromptOutput[]
 
   @@index([userId])
   @@map("prompts")
 }
+


### PR DESCRIPTION
### PR introduces two key updates to the Prisma schema:

- Adds imageUrl field to the User model to support user profile images.

- Introduces a new PromptOutput model to store responses from the Gemini API, including versioning, metadata, and relations to User and Prompt.