### PR TITLE
Users/ayer/delete

### DIFF
--- a/backend/__mocks__/mockUsersRoute.ts
+++ b/backend/__mocks__/mockUsersRoute.ts
@@ -24,20 +24,5 @@ export const createMockUser = (): MockUser => ({
     createdAt: new Date("2024-01-01T00:00:00Z"),
 });
 
-/**
- * Generate JWT token based on a mock user
- */
-export const createMockToken = (user: MockUser): string => {
-    return generateToken(user);
-};
-
-/**
- * Generate both mock user and token
- */
-export const createMockUserAndToken = () => {
-    const user = createMockUser();
-    const token = createMockToken(user);
-    return { user, token };
-};
 
 

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -14,3 +14,19 @@ export const getUserById = async (id: string | undefined): Promise<User | null> 
         throw new Error("Failed to retrieve user");
     }
 };
+
+
+export const deleteUserById = async (id: string | undefined): Promise<User | null> => {
+    try {
+        if (!id) return null;
+
+        const deletedUser = await prisma.user.delete({
+            where: { id },
+        });
+
+        return deletedUser;
+    } catch (error) {
+        console.error("Error fetching user by ID:", error);
+        throw new Error("Failed to retrieve user");
+    }
+};

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import {Request, Response, Router} from "express";
 import {authMiddleware} from "../middleware/index.js";
-import {getUserById} from "../controllers/userController.js";
+import {deleteUserById, getUserById} from "../controllers/userController.js";
 import {mapUserToPublic} from "../types/mapper/userMapper.js";
 
 export const userRoute: Router = Router({});
@@ -57,6 +57,60 @@ userRoute.get("/me", authMiddleware, async (req: Request, res: Response): Promis
         res.status(200).json({user: mapUserToPublic(user)});
     } catch (error) {
         res.status(500).json({error: "Internal server error"});
+    }
+});
+
+
+
+/**
+ * @swagger
+ * /me:
+ *   delete:
+ *     summary: Delete the currently authenticated user
+ *     description: Deletes the authenticated user account.
+ *     tags:
+ *       - User
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       204:
+ *         description: User successfully deleted
+ *       404:
+ *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: User not found
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Internal server error
+ */
+userRoute.delete("/me", authMiddleware, async (req: Request, res: Response): Promise<void> => {
+    try {
+        const userId = req.userId;
+
+        const user = await getUserById(userId);
+        if (!user) {
+            res.status(404).json({ error: "User not found" });
+            return;
+        }
+
+        await deleteUserById(userId);
+        res.status(204).send();
+    } catch (error) {
+        console.error("Error deleting user:", error);
+        res.status(500).json({ error: "Internal server error" });
     }
 });
 


### PR DESCRIPTION
## Delete Authenticated User
This PR implements the DELETE /users/me endpoint and adds comprehensive test coverage.

### What’s Included
- Added DELETE /users/me route to allow authenticated users to delete their own account

- Created unit tests for successful deletion, missing/invalid tokens, user not found, and server errors

- Reused getSignedTestJWT and JWT_SECRET for consistent token generation in tests

- Refactored test file to avoid duplication in setup logic

### Test Coverage
- User successfully deleted (204 No Content)

- Token missing or invalid (401 Unauthorized)

- User not found before/after authentication (401 / 404)

- Simulated DB error (500 Internal Server Error)