### PR TITLE
feat(cors): allow multiple origins for frontend including Netlify and…

### DIFF
--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -11,12 +11,12 @@ export const configApp = () => {
     app.use(express.json());
 
     setupSwagger(app);
-    const allowedOrigin = process.env.CLIENT_URL || 'http://localhost:5173';
+    const allowedOrigins = process.env.HOME_REACT_ADDRESS?.split(',') || ['http://localhost:5173'];
 
     app.use(cookieParser());
     app.use(
         cors({
-            origin: allowedOrigin,
+            origin: allowedOrigins,
             credentials: true,
         })
     );


### PR DESCRIPTION
### Description

This PR updates the CORS configuration in the backend to support multiple allowed origins. It enables smooth communication between the backend and both the production frontend (https://prompto37.netlify.app) and the local development frontend (http://localhost:5173).

Make authenticated requests from:
- http://localhost:5173
- https://prompto37.netlify.app