### PR TITLE
Users/nkolesnikova/update redirect links

### DIFF
--- a/backend/__tests__/config/reactRedirectAddress.test.ts
+++ b/backend/__tests__/config/reactRedirectAddress.test.ts
@@ -1,0 +1,38 @@
+describe("React redirect address", () => {
+  const appEnv = process.env;
+
+  beforeEach(() => {
+    // Reset modules cache before each test
+    jest.resetModules();
+    process.env = { ...appEnv };
+  });
+
+  afterAll(() => {
+    // Set app environment to the original value
+    process.env = appEnv;
+  });
+
+  test("sets correct url in development", async () => {
+    process.env.NODE_ENV = "development";
+    const { HOME_REACT_ADDRESS } = await import(
+      "../../src/config/reactRedirectAddress"
+    );
+    expect(HOME_REACT_ADDRESS).toContain("localhost");
+  });
+
+  test("sets correct development url in undefined environment", async () => {
+    process.env.NODE_ENV = "";
+    const { HOME_REACT_ADDRESS } = await import(
+      "../../src/config/reactRedirectAddress"
+    );
+    expect(HOME_REACT_ADDRESS).toContain("localhost");
+  });
+
+  test("sets correct url in production", async () => {
+    process.env.NODE_ENV = "production";
+    const { HOME_REACT_ADDRESS } = await import(
+      "../../src/config/reactRedirectAddress"
+    );
+    expect(HOME_REACT_ADDRESS).toContain("netlify");
+  });
+});

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -12,4 +12,5 @@ export default {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
+  setupFilesAfterEnv: ["dotenv/config"],
 };

--- a/backend/src/config/authConfig.ts
+++ b/backend/src/config/authConfig.ts
@@ -1,4 +1,4 @@
-export const isProduction = process.env.NODE_ENV === "production";
+import { isProduction } from "./isProduction.js";
 
 // GitHub OAuth variables
 export const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;

--- a/backend/src/config/cookieOptions.ts
+++ b/backend/src/config/cookieOptions.ts
@@ -1,6 +1,6 @@
 import { CookieOptions } from "express";
 
-import { isProduction } from "./authConfig.js";
+import { isProduction } from "./isProduction.js";
 
 export const cookieOptions: CookieOptions = {
   httpOnly: true,

--- a/backend/src/config/isProduction.ts
+++ b/backend/src/config/isProduction.ts
@@ -1,0 +1,1 @@
+export const isProduction = process.env.NODE_ENV === "production";

--- a/backend/src/config/reactRedirectAddress.ts
+++ b/backend/src/config/reactRedirectAddress.ts
@@ -1,2 +1,20 @@
-export const HOME_REACT_ADDRESS = process.env.HOME_REACT_ADDRESS;
+import { isProduction } from "./isProduction.js";
+
+const getReactAddress = (isProd: boolean) => {
+  try {
+    const urls = process.env.HOME_REACT_ADDRESS?.split(",");
+    if (!urls) throw new Error("React urls are not available.");
+
+    const [PROD_URL, DEV_URL]: string[] = urls;
+    return isProd ? PROD_URL : DEV_URL;
+  } catch (error: unknown) {
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : "Failed to define HOME_REACT_ADDRESS"
+    );
+  }
+};
+
+export const HOME_REACT_ADDRESS = getReactAddress(isProduction);
 export const LOGGED_IN_REACT_ADDRESS = `${HOME_REACT_ADDRESS}/`;


### PR DESCRIPTION
These changes propose an update to how a user gets redirected upon being successfully authenticated.
`isProduction` boolean is moved out of `authConfig` so that more files can use it.
A url is being conditionally defined through `isProduction` boolean.

Tests are added.


```typescript
    const urls = process.env.HOME_REACT_ADDRESS?.split(",");
    if (!urls) throw new Error("React urls are not available.");

    const [PROD_URL, DEV_URL]: string[] = urls;
    return isProd ? PROD_URL : DEV_URL;
```