### PR TITLE
update(backend/config): Improve linter config to recognize typescript…

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,11 +1,22 @@
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import tsParser from "@typescript-eslint/parser";
 import prettier from "eslint-plugin-prettier";
 
 export default defineConfig({
   ignores: ["dist"],
   extends: [js.configs.recommended, ...tseslint.configs.recommended],
   files: ["**/*.{js,ts}"],
-  plugins: prettier,
+  plugins: { prettier },
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: "latest",
+    sourceType: "module",
+    globals: {
+      node: true,
+      console: true,
+      process: true,
+    },
+  },
 });

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -12,5 +12,6 @@ export default {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
+  setupFiles: ["dotenv/config"],
   setupFilesAfterEnv: ["dotenv/config"],
 };


### PR DESCRIPTION
Updated linter config to improve TypeScript interaction. With these changes it no longer throws an error for 'process' or 'console'.

Added this piece:

```typescript
languageOptions: {
    parser: tsParser,
    ecmaVersion: "latest",
    sourceType: "module",
    globals: {
      node: true,
      console: true,
      process: true,
    },
  },
```