### PR TITLE
update(workflows): Add environment variables to the workflow configur…

### DIFF
--- a/.github/workflows/pre-push.yaml
+++ b/.github/workflows/pre-push.yaml
@@ -15,6 +15,14 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    environment: Testing
+    # Env is now available for all steps within the 'build' job
+    env:
+      HOME_REACT_ADDRESS: ${{secrets.HOME_REACT_ADDRESS}}
+      JWT_SECRET: ${{secrets.JWT_SECRET}}
+      DATABASE_URL: ${{secrets.DATABASE_URL}}
+      GEMINI_API_KEY: ${{secrets.GEMINI_API_KEY}}
+      NODE_ENV: "test"
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -5,7 +5,7 @@ import tsParser from "@typescript-eslint/parser";
 import prettier from "eslint-plugin-prettier";
 
 export default defineConfig({
-  ignores: ["dist"],
+  ignores: ["dist/**"],
   extends: [js.configs.recommended, ...tseslint.configs.recommended],
   files: ["**/*.{js,ts}"],
   plugins: { prettier },

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -18,7 +18,9 @@ export const envSchema = z.object({
   GEMINI_API_KEY: z.string().min(10),
   JWT_SECRET: z.string().min(10),
   SESSION_SECRET: z.string().min(15),
-  NODE_ENV: z.enum(["development", "production"]).default("development"),
+  NODE_ENV: z
+    .enum(["development", "production", "test"])
+    .default("development"),
 });
 
 // Validate `process.env` against our schema


### PR DESCRIPTION
Added environment variables to the workflow.

Created a 'Testing' environment in GitHub Actions. The following env variables are added:

<p align="center">
<img width="600" src="https://github.com/user-attachments/assets/ee116d5f-b61c-4c00-998f-75fd38f8f9ee" />
</p>
In the workflow:

```yaml
    environment: Testing
    # Env is now available for all steps within the 'build' job
    env:
      HOME_REACT_ADDRESS: ${{secrets.HOME_REACT_ADDRESS}}
      JWT_SECRET: ${{secrets.JWT_SECRET}}
      DATABASE_URL: ${{secrets.DATABASE_URL}}
      GEMINI_API_KEY: ${{secrets.GEMINI_API_KEY}}
      NODE_ENV: "test"
```

---

Added a fix to the linter that properly ignores '/dist' folder.

Extended `zod` types to include 'test'.