### PR TITLE
Users/nkolesnikova/expand cors

### DIFF
--- a/backend/src/config/cookieOptions.ts
+++ b/backend/src/config/cookieOptions.ts
@@ -1,9 +1,15 @@
 import { CookieOptions } from "express";
 
 import { isProduction } from "./isProduction.js";
+import { HOME_REACT_ADDRESS } from "./reactRedirectAddress.js";
 
 export const cookieOptions: CookieOptions = {
   httpOnly: true,
   secure: isProduction,
   sameSite: isProduction ? "none" : "lax",
+  // Isolate cookies and other site data - preventing cross-site tracking
+  partitioned: isProduction, // for privacy-focused browsers, requires 'secure'
+  domain: new URL(HOME_REACT_ADDRESS).hostname, // lock the domain
+  path: "/", // for cross-route access,
+  priority: "high",
 };

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -2,8 +2,10 @@ import express from "express";
 import path from "path";
 import cookieParser from "cookie-parser";
 import session from "express-session";
-import { authRoute, promptRoute, userRoute } from "../routes/index.js";
 import cors from "cors";
+
+import { securityHeaders } from "../middleware/index.js";
+import { authRoute, promptRoute, userRoute } from "../routes/index.js";
 
 export const configApp = async () => {
   const app = express();
@@ -17,10 +19,15 @@ export const configApp = async () => {
   const allowedOrigins = process.env.HOME_REACT_ADDRESS?.split(",");
 
   app.use(cookieParser());
+  app.use(securityHeaders); // Security headers for privacy-focused browsers
+
   app.use(
     cors({
       origin: allowedOrigins,
       credentials: true,
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Cookie", "Set-Cookie"],
+      exposedHeaders: ["Set-Cookie"],
     })
   );
 
@@ -32,7 +39,6 @@ export const configApp = async () => {
   app.use(
     session({ secret: sessionSecret, resave: false, saveUninitialized: true })
   );
-  app.use(express.json());
 
   app.use("/", authRoute);
   app.use("/users", userRoute);

--- a/backend/src/config/settings.ts
+++ b/backend/src/config/settings.ts
@@ -4,7 +4,7 @@ import cookieParser from "cookie-parser";
 import session from "express-session";
 import cors from "cors";
 
-import { securityHeaders } from "../middleware/index.js";
+import { corsOptions, securityHeaders } from "../middleware/index.js";
 import { authRoute, promptRoute, userRoute } from "../routes/index.js";
 
 export const configApp = async () => {
@@ -16,20 +16,9 @@ export const configApp = async () => {
     setupSwagger(app);
   }
 
-  const allowedOrigins = process.env.HOME_REACT_ADDRESS?.split(",");
-
   app.use(cookieParser());
   app.use(securityHeaders); // Security headers for privacy-focused browsers
-
-  app.use(
-    cors({
-      origin: allowedOrigins,
-      credentials: true,
-      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-      allowedHeaders: ["Content-Type", "Cookie", "Set-Cookie"],
-      exposedHeaders: ["Set-Cookie"],
-    })
-  );
+  app.use(cors(corsOptions));
 
   // Serve static files
   const __dirname = path.resolve();

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -60,6 +60,7 @@ export const logout = async (req: Request, res: Response) => {
   try {
     // clear user session
     res.clearCookie("token", cookieOptions);
+    res.header("Clear-Site-Data", "cookies"); // Safari log out header
     res.status(200).json({ message: "Logged out successfully" });
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : String(error));
@@ -95,6 +96,7 @@ const sendCookieAndRedirect = (res: Response, user: User) => {
   try {
     const token = generateToken(user);
     res.cookie("token", token, cookieOptions);
+    res.header("Authorization", `Bearer ${token}`); // Fallback for privacy blockers
     res.redirect(LOGGED_IN_REACT_ADDRESS);
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : String(error));

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -8,8 +8,11 @@ export const authMiddleware = async (
   res: Response,
   next: NextFunction
 ) => {
-  // Extract the token from cookies
-  const token = req.cookies.token;
+  // Extract the token from cookies or headers
+  const token =
+    req.cookies.token ??
+    (req.headers.authorization &&
+      extractHeaderToken(req.headers.authorization));
 
   if (!token) {
     res
@@ -46,4 +49,10 @@ export const authMiddleware = async (
     });
     return;
   }
+};
+
+const extractHeaderToken = (authorization: string) => {
+  const [bearer, token] = authorization.split(" ");
+  if (bearer.trim() !== "Bearer") return;
+  return token;
 };

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from "express";
+
+const allowedOrigins = process.env.HOME_REACT_ADDRESS?.split(",");
+
+export const corsOptions = {
+  origin: allowedOrigins,
+  credentials: true,
+  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"],
+  allowedHeaders: ["Content-Type", "Cookie", "Set-Cookie", "Authorization"],
+  exposedHeaders: ["Set-Cookie", "Authorization"],
+};
+
+export const securityHeaders = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // Allow cross-origin access to resources
+  res.header("Cross-Origin-Resource-Policy", "cross-origin");
+  // Limit tracking data leakage
+  res.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  // Reduces cookie blocking in Chromium-based privacy browsers
+  res.header("Permissions-Policy", "interest-cohort=()");
+  // Restricts all resource loading to same-origin by default
+  res.header("Content-Security-Policy", "default-src 'self'");
+  // Disables MIME type sniffing
+  res.header("X-Content-Type-Options", "nosniff");
+  // Prevent a web page from being displayed in a frame or iframe, regardless of the origin
+  res.header("X-Frame-Options", "deny");
+  next();
+};

--- a/backend/src/middleware/index.ts
+++ b/backend/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export * from "./authMiddleware.js";
 export * from "./rateLimiter.js";
+export * from "./cors.js";


### PR DESCRIPTION
These changes propose to expand cookie and cors configs.

## Cors
The following header is supposed to be helpful, but might throw errors, so I expect this could potentially be disabled in the future:
```typescript
  // Reduces cookie blocking in Chromium-based privacy browsers
  res.header("Permissions-Policy", "interest-cohort=()");
```

## Cookies
```typescript
  // Isolate cookies and other site data - preventing cross-site tracking
  partitioned: isProduction, // for privacy-focused browsers, requires 'secure'
  domain: new URL(HOME_REACT_ADDRESS).hostname, // lock the domain
  path: "/", // for cross-route access,
  priority: "high",
 ```
Docs on state partitioning: https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/State_Partitioning

## Authorization Bearer
Additionally, an auth token can be placed into `Authorization` header with a `Bearer` prefix - this increases chances of the token being passed around in browsers with a privacy focus:
```typescript
    res.header("Authorization", `Bearer ${token}`); // Fallback for privacy blockers
```