### PR TITLE
Users/nkolesnikova/expand cors

### DIFF
--- a/backend/src/config/cookieOptions.ts
+++ b/backend/src/config/cookieOptions.ts
@@ -1,7 +1,6 @@
 import { CookieOptions } from "express";
 
 import { isProduction } from "./isProduction.js";
-import { HOME_REACT_ADDRESS } from "./reactRedirectAddress.js";
 
 export const cookieOptions: CookieOptions = {
   httpOnly: true,
@@ -9,7 +8,7 @@ export const cookieOptions: CookieOptions = {
   sameSite: isProduction ? "none" : "lax",
   // Isolate cookies and other site data - preventing cross-site tracking
   partitioned: isProduction, // for privacy-focused browsers, requires 'secure'
-  domain: new URL(HOME_REACT_ADDRESS).hostname, // lock the domain
-  path: "/", // for cross-route access,
+  domain: isProduction ? ".netlify.app" : "localhost", // lock the domain explicitly
+  path: "/", // for cross-route access
   priority: "high",
 };

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,9 +1,20 @@
+import { CorsOptions } from "cors";
 import { NextFunction, Request, Response } from "express";
 
 const allowedOrigins = process.env.HOME_REACT_ADDRESS?.split(",");
 
-export const corsOptions = {
-  origin: allowedOrigins,
+export const corsOptions: CorsOptions = {
+  // Handle origins dynamically
+  origin: (
+    origin: string | undefined,
+    callback: (err: Error | null, allow?: boolean) => void
+  ) => {
+    if (!origin || allowedOrigins?.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error("Origin restricted by CORS"));
+    }
+  },
   credentials: true,
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"],
   allowedHeaders: ["Content-Type", "Cookie", "Set-Cookie", "Authorization"],
@@ -15,17 +26,22 @@ export const securityHeaders = (
   res: Response,
   next: NextFunction
 ) => {
+  // Accept partitioned cookies
+  res.header("Accept-CH", "Sec-CH-Partitioned-Cookies");
   // Allow cross-origin access to resources
-  res.header("Cross-Origin-Resource-Policy", "cross-origin");
+  res.header("Cross-Origin-Resource-Policy", "same-site");
   // Limit tracking data leakage
   res.header("Referrer-Policy", "strict-origin-when-cross-origin");
   // Reduces cookie blocking in Chromium-based privacy browsers
-  res.header("Permissions-Policy", "interest-cohort=()");
+  // Browsing topics for FireFox
+  res.header("Permissions-Policy", "interest-cohort=(), browsing-topics=()");
   // Restricts all resource loading to same-origin by default
   res.header("Content-Security-Policy", "default-src 'self'");
   // Disables MIME type sniffing
   res.header("X-Content-Type-Options", "nosniff");
   // Prevent a web page from being displayed in a frame or iframe, regardless of the origin
   res.header("X-Frame-Options", "deny");
+  // Ensure Render doesn't modify headers
+  res.header("Cache-Control", "no-transform");
   next();
 };


### PR DESCRIPTION
### Currently, a user is being authenticated in a production environment in FireFox, and we are getting back the `token`:

![Screenshot 2025-04-08 100924](https://github.com/user-attachments/assets/02e00848-25e8-4b93-bc38-f10f98fe4d36)

### However, the server will reject a subsequent request to '/users/me'. I am proposing some additional config that should solve some misconfigurations. Pushing this will us help to navigate the issues further. 

---

Added dynamic handling of origins to ensure correct parsing of origins.

I noticed that cookies are being set to "Lax" despite production config - added explicit domains in cookieOptions to prevent "Lax" setting that Netlify sets if domains are misconfigured:
```typescript
  domain: isProduction ? ".netlify.app" : "localhost", // lock the domain explicitly
  ```

Additional headers to make sure that cookies are not blocked:
```typescript
  // Browsing topics for FireFox
  res.header("Permissions-Policy", "interest-cohort=(), browsing-topics=()");
  // Accept partitioned cookies
  res.header("Accept-CH", "Sec-CH-Partitioned-Cookies");
  // Ensure Render doesn't modify headers
  res.header("Cache-Control", "no-transform");
```