### PR TITLE
update(backend/auth): Rename "googleAuthState" to "google", "githubAu…

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -13,11 +13,11 @@ const handleSignIn = async (
   req: Request,
   res: Response,
   authService: typeof googleAuth | typeof githubAuth,
-  sessionState: string
+  authProvider: string
 ) => {
   try {
     const state = generateRandomHexString();
-    (req.session as GSession)[sessionState] = state;
+    (req.session as GSession)[authProvider] = state;
     // Generate a url that asks permissions defined scopes
     const authorizationUrl = authService.generateAuthUrl(state);
     if (!authorizationUrl) {
@@ -37,18 +37,18 @@ const handleCallback = async (
   req: Request,
   res: Response,
   authService: typeof googleAuth | typeof githubAuth,
-  sessionState: string
+  authProvider: string
 ) => {
   try {
     const user = await authService.authenticate(req);
     if (!user) return;
-    sendCookieAndRedirect(res, user);
+    sendCookieAndRedirect(res, user, authProvider);
   } catch (error) {
     console.error(error);
     const redirectUrl = `${HOME_REACT_ADDRESS}/?error=${error}`;
     res.redirect(String(redirectUrl));
   } finally {
-    (req.session as GSession)[sessionState] = "";
+    (req.session as GSession)[authProvider] = "";
   }
 };
 
@@ -66,33 +66,33 @@ export const logout = async (req: Request, res: Response) => {
 // GitHub
 // =======================================
 export const githubSignIn = async (req: Request, res: Response) => {
-  handleSignIn(req, res, githubAuth, "githubAuthState");
+  handleSignIn(req, res, githubAuth, "github");
 };
 
 export const githubCallback = async (req: Request, res: Response) => {
-  handleCallback(req, res, githubAuth, "githubAuthState");
+  handleCallback(req, res, githubAuth, "github");
 };
 
 // =======================================
 // Google
 // =======================================
 export const googleSignIn = async (req: Request, res: Response) => {
-  handleSignIn(req, res, googleAuth, "googleAuthState");
+  handleSignIn(req, res, googleAuth, "google");
 };
 
 export const googleCallback = async (req: Request, res: Response) => {
-  handleCallback(req, res, googleAuth, "googleAuthState");
+  handleCallback(req, res, googleAuth, "google");
 };
 
 // =======================================
 // Send cookie and redirect to React
 // =======================================
-const sendCookieAndRedirect = (res: Response, user: User) => {
+const sendCookieAndRedirect = (res: Response, user: User, authProvider: string) => {
   try {
     const token = generateToken(user);
     res.cookie("token", token, cookieOptions);
     res.header("Authorization", `Bearer ${token}`); // Fallback for privacy blockers
-    res.redirect(LOGGED_IN_REACT_ADDRESS);
+    res.redirect(`${LOGGED_IN_REACT_ADDRESS}?authProvider=${authProvider}`);
   } catch (error) {
     throw new Error(error instanceof Error ? error.message : String(error));
   }

--- a/backend/src/services/GitHubAuth.ts
+++ b/backend/src/services/GitHubAuth.ts
@@ -46,7 +46,7 @@ class GitHubAuth {
   authenticate = async (req: Request) => {
     try {
       // Extract authorization code that will be exchanged for user tokens
-      const code = extractCode(req, (req.session as GSession).githubAuthState);
+      const code = extractCode(req, (req.session as GSession).github);
       // Because we are communicating directly with a GitHub server,
       // We can be confident that the token is valid
       const access_token = await this.getAccessToken(String(code));

--- a/backend/src/services/GoogleAuth.ts
+++ b/backend/src/services/GoogleAuth.ts
@@ -58,7 +58,7 @@ class GoogleAuth {
   authenticate = async (req: Request) => {
     try {
       // Extract authorization code that will be exchanged for user tokens
-      const code = extractCode(req, (req.session as GSession).googleAuthState);
+      const code = extractCode(req, (req.session as GSession).google);
       // Because we are communicating directly with a Google server,
       // We can be confident that the token is valid
       const { tokens } = await this.getToken(code);


### PR DESCRIPTION
Renamed variables to be more semantic:
- `googleAuthState` -> `google`;
- `githubAuthState` -> `github`;  
- `sessionState` -> `authProvider`.  

--- 

Redirecting to React with an auth provider that a user picked for that particular session:
```typescript
res.redirect(`${LOGGED_IN_REACT_ADDRESS}?authProvider=${authProvider}`);
```

`authProvider` will equal either `google` or `github`.